### PR TITLE
Update repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/donavon/event-listener.git"
+    "url": "https://github.com/donavon/use-event-listener.git"
   },
   "scripts": {
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
Saw that the repository link was broken on the [npm page](https://www.npmjs.com/package/@use-it/event-listener)