### PR TITLE
Add support check on cleanup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ const useEventListener = (eventName, handler, element = global) => {
       const eventListener = event => savedHandler.current(event);
       element.addEventListener(eventName, eventListener);
       return () => {
+        if (!isSupported) return;
         element.removeEventListener(eventName, eventListener);
       };
     },


### PR DESCRIPTION
Before, the event listener would not be added if the element did not support adding event listeners, but it would error on cleanup when it tries to remove the event listener (`removeEventListener` is not a function). This adds the same check to the cleanup and makes sure that it bails out early if event listeners are not supported.