### PR TITLE
Adds useCapture flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,19 @@ $ yarn add @use-it/event-listener
 Here is a basic setup.
 
 ```js
-useEventListener(eventName, handler, element);
+useEventListener(eventName, handler, element, useCapture);
 ```
 
 ### Parameters
 
 Here are the parameters that you can use. (\* = optional)
 
-| Parameter   | Description                                                                                                      |
-| :---------- | :--------------------------------------------------------------------------------------------------------------- |
-| `eventName` | The event name (string). Here is a list of [common events](https://developer.mozilla.org/en-US/docs/Web/Events). |
-| `handler`   | A function that will be called whenever `eventName` fires on `element`.                                          |
-| `element`\* | An optional element to listen on. Defaults to `global` (i.e., `window`).                                         |
+| Parameter      | Description                                                                                                      |
+| :------------- | :--------------------------------------------------------------------------------------------------------------- |
+| `eventName`    | The event name (string). Here is a list of [common events](https://developer.mozilla.org/en-US/docs/Web/Events). |
+| `handler`      | A function that will be called whenever `eventName` fires on `element`.                                          |
+| `element`\*    | An optional element to listen on. Defaults to `global` (i.e., `window`).                                         |
+| `useCapture`\* | An optional flag to use the capturing event mode..                                                               |
 
 ### Return
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -6,13 +6,16 @@ import useEventListener from '../src';
 
 const mouseMoveEvent = { clientX: 100, clientY: 200 };
 let hackHandler = null;
+let useCaptureHandler = null;
 
 const mockElement = {
-  addEventListener: (eventName, handler) => {
+  addEventListener: (eventName, handler, useCapture = false) => {
     hackHandler = handler;
+    useCaptureHandler = useCapture;
   },
   removeEventListener: () => {
     hackHandler = null;
+    useCaptureHandler = null;
   },
   dispatchEvent: (event) => {
     hackHandler(event);
@@ -35,6 +38,7 @@ describe('useEventListener', () => {
     });
 
     expect(addEventListenerSpy).toBeCalled();
+    expect(useCaptureHandler).toBe(false);
 
     mockElement.dispatchEvent(mouseMoveEvent);
     expect(handler).toBeCalledWith(mouseMoveEvent);
@@ -51,6 +55,23 @@ describe('useEventListener', () => {
     });
 
     expect(addEventListenerSpy).toBeCalled();
+
+    addEventListenerSpy.mockRestore();
+  });
+
+  test('you pass an additional `useCapture`', () => {
+    const handler = jest.fn();
+    const addEventListenerSpy = jest.spyOn(mockElement, 'addEventListener');
+
+    testHook(() => {
+      useEventListener('foo', handler, mockElement, true);
+    });
+
+    expect(addEventListenerSpy).toBeCalled();
+    expect(useCaptureHandler).toBe(true);
+
+    mockElement.dispatchEvent(mouseMoveEvent);
+    expect(handler).toBeCalledWith(mouseMoveEvent);
 
     addEventListenerSpy.mockRestore();
   });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { useRef, useEffect } from 'react';
 
-const useEventListener = (eventName, handler, element = global) => {
+const useEventListener = (eventName, handler, element = global, useCapture = false) => {
   const savedHandler = useRef();
 
   useEffect(() => {
@@ -13,9 +13,9 @@ const useEventListener = (eventName, handler, element = global) => {
       if (!isSupported) return;
 
       const eventListener = event => savedHandler.current(event);
-      element.addEventListener(eventName, eventListener);
+      element.addEventListener(eventName, eventListener, useCapture);
       return () => {
-        element.removeEventListener(eventName, eventListener);
+        element.removeEventListener(eventName, eventListener, useCapture);
       };
     },
     [eventName, element]


### PR DESCRIPTION
Although, in most cases the capture-mode is not required in events, sometimes it is useful. This PR adds the optional `useCapture` flag. Ref: https://developer.mozilla.org/de/docs/Web/API/EventTarget/addEventListener 