### PR TITLE
Replace React.SyntheticEvent by ordinary DOM/window Event on types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,9 @@
-import { EventHandler, SyntheticEvent } from 'react';
-
 /**
  * A custom React Hook that provides a declarative useEventListener.
  */
-declare function useEventListener<T extends SyntheticEvent<any>>(
+declare function useEventListener<T extends Event>(
   eventName: string,
-  handler: EventHandler<T>,
+  handler: (event: T) => void,
   element?: HTMLElement
 ): void;
 


### PR DESCRIPTION
The motivation behind this PR is that we're not listening to React events. Instead, `useEventListener` listens to DOM/window events, so the typings are wrong. There's no SyntheticEvent in the handler.

More: https://github.com/donavon/use-event-listener/blob/develop/src/index.js#L16