### PR TITLE
chore: make parameter types more specific

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,12 +1,34 @@
-import { EventHandler, SyntheticEvent } from 'react';
-
 /**
  * A custom React Hook that provides a declarative useEventListener.
  */
-declare function useEventListener<T extends SyntheticEvent<any>>(
+declare function useEventListener<K extends keyof HTMLElementEventMap>(
+  eventName: K,
+  handler: HTMLElementEventMap[K],
+  element: HTMLElement
+);
+declare function useEventListener<K extends keyof DocumentEventMap>(
+  eventName: K,
+  handler: DocumentEventMap[K],
+  element: Document
+);
+declare function useEventListener<K extends keyof WindowEventMap>(
+  eventName: K,
+  handler: WindowEventMap[K],
+  element?: Window
+);
+declare function useEventListener(
   eventName: string,
-  handler: EventHandler<T>,
-  element?: HTMLElement
+  handler: EventListenerOrEventListenerObject,
+  element?: HTMLElement | Window | Document
+);
+declare function useEventListener<
+  K extends keyof (HTMLElementEventMap & DocumentEventMap & WindowEventMap)
+>(
+  eventName: K,
+  handler: (
+    event: (HTMLElementEventMap & DocumentEventMap & WindowEventMap)[K]
+  ) => void,
+  element?: HTMLElement | Document | Window
 ): void;
 
 export as namespace useEventListener;


### PR DESCRIPTION
Fixes #14.

This PR adds three extra overloads for the elements of type `HTMLElement`, `Window` and `Document`. It's backwards compatible since the original overload is still included, which is also in line with the TypeScript own [`lib.dom.d.ts` implementation](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L6217).