### PR TITLE
add memoOptions to removeEventListener

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const useEventListener = (eventName, handler, element = global, options) => {
       const eventListener = event => savedHandler.current(event);
       element.addEventListener(eventName, eventListener, memoOptions);
       return () => {
-        element.removeEventListener(eventName, eventListener);
+        element.removeEventListener(eventName, eventListener, memoOptions);
       };
     },
     [eventName, element, memoOptions]


### PR DESCRIPTION
Registered events are not deleted. So the event is always set globally.