### PR TITLE
Support React 17 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "jest": {
     "coverageThreshold": {


### PR DESCRIPTION
This removes warnings when installing the package in projects using React 17.