### PR TITLE
Support default element when running in browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 /* eslint-disable max-params */
 import { useRef, useEffect } from 'react';
 
+const globalObject = typeof window === 'undefined' ? global : window
+
 const useEventListener = (
   eventName,
   handler,
-  element = global,
+  element = globalObject,
   options = {}
 ) => {
   const savedHandler = useRef();


### PR DESCRIPTION
`global` is only defined in Node. `globalThis` will work for most users, but this workaround should work for all environments.

This probably worked because I am guessing that CRA's `webpack` config did some transformations, but when using `vite` no transformation is applied and it fails in the browser. 

For the future it would be best to write browser code where possible rather than relying on tooling to transform to browser code when the tooling can change over time.