### PR TITLE
Switch from `global` to `globalThis`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Here are the parameters that you can use. (\* = optional)
 | :---------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `eventName` | The event name (string). Here is a list of [common events](https://developer.mozilla.org/en-US/docs/Web/Events).                                                                                                                       |
 | `handler`   | A function that will be called whenever `eventName` fires on `element`.                                                                                                                                                                |
-| `element`\* | An optional element to listen on. Defaults to `global` (i.e., `window`).                                                                                                                                                               |
+| `element`\* | An optional element to listen on. Defaults to `globalThis` (i.e., `window`).                                                                                                                                                           |
 | `options`\* | An object `{ capture?: boolean, passive?: boolean, once?: boolean }` to be passed to `addEventListener`. For advanced use cases. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) for details. |
 
 ### Return

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -41,9 +41,9 @@ describe('useEventListener', () => {
     addEventListenerSpy.mockRestore();
   });
 
-  test.skip('`element` is optional (defaults to `window`/`global`)', () => {
+  test.skip('`element` is optional (defaults to `window`/`globalThis`)', () => {
     const handler = jest.fn();
-    const addEventListenerSpy = jest.spyOn(global, 'addEventListener');
+    const addEventListenerSpy = jest.spyOn(globalThis, 'addEventListener');
 
     renderHook(() => useEventListener('foo', handler));
 
@@ -54,7 +54,7 @@ describe('useEventListener', () => {
 
   test.skip('does not add event listener to `window` if `element` is `null`', () => {
     const handler = jest.fn();
-    const addEventListenerSpy = jest.spyOn(global, 'addEventListener');
+    const addEventListenerSpy = jest.spyOn(globalThis, 'addEventListener');
 
     renderHook(() => useEventListener('foo', handler, null));
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { useRef, useEffect } from 'react';
 const useEventListener = (
   eventName,
   handler,
-  element = global,
+  element = globalThis,
   options = {}
 ) => {
   const savedHandler = useRef();


### PR DESCRIPTION
`globalThis` has become a standard which is supported by all major platforms (as of 2023): https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis

Using the non-standard `global` leads to issues like https://github.com/donavon/use-event-listener/pull/55 and https://github.com/donavon/use-persisted-state/issues/62